### PR TITLE
Make JAVA Opts user configurable and bump upper limit to 6g due to error reports from users

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       args:
         UPSTREAM_VERSION: 23.11.0
     environment:
+      JAVA_OPTS: "-Xmx6g -Xms128m"
       EXTRA_OPTS: ""
     volumes:
       - "web3signer_data:/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       args:
         UPSTREAM_VERSION: 23.11.0
     environment:
-      JAVA_OPTS: "-Xmx6g -Xms128m"
+      JAVA_OPTS: "-Xmx4g -Xms128m"
       EXTRA_OPTS: ""
     volumes:
       - "web3signer_data:/data"

--- a/web3signer/Dockerfile
+++ b/web3signer/Dockerfile
@@ -6,6 +6,5 @@ USER root
 COPY entrypoint.sh /usr/bin/entrypoint.sh
 
 #USER web3signer
-ENV JAVA_OPTS="-Xmx4g -Xms128m"
 EXPOSE 9000
 ENTRYPOINT /bin/bash /usr/bin/entrypoint.sh


### PR DESCRIPTION
Same logic as 
https://github.com/dappnode/DAppNodePackage-web3signer-gnosis/pull/76