### PR TITLE
Bump brain 0.1.17

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.14
+FROM ghcr.io/dappnode/staking-brain:0.1.17
 ENV NETWORK=lukso

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -32,7 +32,8 @@
     "minimumDappnodeVersion": "0.2.89"
   },
   "optionalDependencies": {
-    "prysm.dnp.dappnode.eth": "0.1.1"  },
+    "prysm-lukso.dnp.dappnode.eth": "0.1.1"
+  },
   "globalEnvs": [
     {
       "envs": ["CONSENSUS_CLIENT_LUKSO", "EXECUTION_CLIENT_LUKSO"],

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -29,8 +29,10 @@
   },
   "license": "Apache-2.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.77"
+    "minimumDappnodeVersion": "0.2.89"
   },
+  "optionalDependencies": {
+    "prysm.dnp.dappnode.eth": "0.1.1"  },
   "globalEnvs": [
     {
       "envs": ["CONSENSUS_CLIENT_LUKSO", "EXECUTION_CLIENT_LUKSO"],


### PR DESCRIPTION
Bump brain to `v0.1.17` to match new auth-token for Prysm validator